### PR TITLE
Expand test step to run all test projects

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -62,13 +62,13 @@ steps:
         projects: ${{ parameters.projectFolder }}/*.csproj
 
   - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests'
+    displayName: 'Run Tests'
     condition: eq(${{parameters.runTests}}, true)
     inputs:
       command: test
       ${{ if eq(parameters.testFolder, '') }}:
         projects: |
-          **/*[Uu]nit[Tt]ests/*.csproj
+          **/*[Tt]ests/*.csproj
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj


### PR DESCRIPTION
Currently filters to UnitTests, but that misses the new "Integration Tests" project in regulator service
https://github.com/DEFRA/epr-regulator-service/blob/0bd499742155236b54aeb465f6d415b975826968/src/IntegrationTests/IntegrationTests.csproj

Relax the filter to find all project suffixed with "Test"

https://eaflood.atlassian.net/browse/AMCR-42