### PR TITLE
Show capture image name in get-docker-tag step

### DIFF
--- a/templates/get-current-dockertag.yaml
+++ b/templates/get-current-dockertag.yaml
@@ -23,5 +23,6 @@ steps:
           Write-Error "Unknown Service Type"
           exit 1
         }
+        Write-Host "Current image: $currentImageTag"
         Write-Host "##vso[task.setvariable variable=currentImageTag;]$currentImageTag"
    


### PR DESCRIPTION
Caused confusion because although it's working it's not obvious till it's shown in the next step.

Fixes https://eaflood.atlassian.net/browse/AMCR-43