### PR TITLE
Revert "Expand test step to run all test projects (#19)"

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -62,13 +62,13 @@ steps:
         projects: ${{ parameters.projectFolder }}/*.csproj
 
   - task: DotNetCoreCLI@2
-    displayName: 'Run Tests'
+    displayName: 'Run Unit Tests'
     condition: eq(${{parameters.runTests}}, true)
     inputs:
       command: test
       ${{ if eq(parameters.testFolder, '') }}:
         projects: |
-          **/*[Tt]ests/*.csproj
+          **/*[Uu]nit[Tt]ests/*.csproj
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj


### PR DESCRIPTION
This reverts commit 1e75a13fa66580440d4240f550126edbd63539a8.

Turns out this causes some of the builds to fail as they have tests that
don't work that aren't currently being run.

https://eaflood.atlassian.net/browse/AMCR-42