### PR TITLE
Add git sha to docker build and tag

### DIFF
--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -49,7 +49,7 @@ steps:
       buildContext: ${{parameters.solutionFolder}}/${{parameters.componentDirectory}}
       dockerfile: ${{parameters.solutionFolder}}/${{parameters.componentDirectory}}/${{parameters.projectFolder}}/Dockerfile
       tags: $(Build.BuildNumber)
-      arguments: '--build-arg PAT=$(VSS_NUGET_ACCESSTOKEN)'
+      arguments: '--build-arg PAT=$(VSS_NUGET_ACCESSTOKEN) --build-arg BUILD_NUMBER=$(Build.BuildNumber) --build-arg GIT_SHA=$(Build.SourceVersion)'
 
   - task: AzureCLI@2
     displayName: 'Push Docker Image to ACR'

--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -69,6 +69,9 @@ steps:
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
 
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+
         elif [[ $(branchName) == releases* ]]
           then
             echo -e "\033[0;32m Procesing RELEASES image"
@@ -78,9 +81,15 @@ steps:
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
 
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+
         else
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
+
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
         fi
 
   - bash: |
@@ -93,11 +102,14 @@ steps:
           then
             echo -e "\033[0;32m $(branchName)-latest"
             echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
+            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
         elif [[ $(branchName) == releases* ]]
           then
             echo -e "\033[0;32m $(branchName)"
             echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
+            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
         else
             echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
+            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
         fi
     displayName: "NAME OF THE IMAGE"


### PR DESCRIPTION
- **Add source code git sha to docker image tags**
  To make it easier to work out which version of the code is deployed
  
  Working on https://eaflood.atlassian.net/browse/AMCR-71 and want to validate correct version is deployed to dev env easily.
  Also supports ongoing path to prod work.
  

- **Pass build metadata as Docker build args**
  Add BUILD_NUMBER and GIT_SHA as build arguments to the Docker build
  step. These can be received by Dockerfiles using ARG/ENV directives
  to make version information available to the running application.
  
  Consuming Dockerfiles need to add:
  
  ```
  ARG BUILD_NUMBER
  ARG GIT_SHA
  ENV BUILD_NUMBER=$BUILD_NUMBER
  ENV GIT_SHA=$GIT_SHA
  ```
  
Tested a deploy of this with https://github.com/DEFRA/epr-obligationchecker-frontend/pull/96

New header meta tags :

<img width="1414" height="543" alt="shutter_20262-20_04" src="https://github.com/user-attachments/assets/f897025a-29d2-4261-adb4-a0f9a5bd9d03" />

Container registry with git sha tag:

<img width="908" height="258" alt="shutter_20262-20_03" src="https://github.com/user-attachments/assets/cbbf8221-c9a1-415f-b571-a654773ce063" />
