### PR TITLE
Enable a unique name for the OWASP build artifact

### DIFF
--- a/templates/owaspcheck.yaml
+++ b/templates/owaspcheck.yaml
@@ -106,7 +106,7 @@ steps:
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(System.DefaultWorkingDirectory)/${{parameters.solutionFolder}}/dependency-check-report.html'
-      artifact: 'OWASP DOCKER HTML'
+      artifact: $(System.JobAttempt)-owasp-report
       publishLocation: 'pipeline'
     displayName: 'Publish OWASP Artifact'
   


### PR DESCRIPTION
Build artifacts are immutable by design; therefore, enable a unique name for the OWASP build artifact/report to cater for a manual re-run of the same instance