### PR TITLE
Add testPattern parameter to build template

### DIFF
--- a/epr-build-pipeline.yaml
+++ b/epr-build-pipeline.yaml
@@ -16,6 +16,9 @@ parameters:
 - name: runTests
   type: boolean
   default: true
+- name: testPattern
+  type: string
+  default: ''
 - name: runIntegrationTests
   type: boolean
   default: false
@@ -97,6 +100,7 @@ stages:
               sonarQubeProjectKey: ${{ parameters.sonarQubeProjectKey }}
               sonarQubeProjectName: ${{ parameters.sonarQubeProjectName }}
               runTests: ${{ parameters.runTests }}
+              testPattern: ${{ parameters.testPattern }}
               runIntegrationTests: ${{ parameters.runIntegrationTests }}
               runNugetTasks: ${{ parameters.runNugetTasks }}
               sonarqubeInstance: ${{ parameters.sonarqubeInstance }}

--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -8,6 +8,9 @@ parameters:
   - name: testFolder
     type: string
     default: ''
+  - name: testPattern
+    type: string
+    default: ''
   - name: sonarQubeProjectKey
     type: string
   - name: sonarQubeProjectName
@@ -66,12 +69,12 @@ steps:
     condition: eq(${{parameters.runTests}}, true)
     inputs:
       command: test
-      ${{ if eq(parameters.testFolder, '') }}:
+      ${{ if eq(parameters.testPattern, '') }}:
         projects: |
           **/*[Uu]nit[Tt]ests/*.csproj
       ${{else}}:
         projects:  |
-          ${{ parameters.testFolder}}/**/*.csproj
+          ${{ parameters.testPattern}}
       arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover'
       publishTestResults: true
 


### PR DESCRIPTION
To allow control over how to find test projects to run.

Needed to be able to run new integration tests in regulator frontend without affecting other projects.

The [`testFolder` param is defined in `analyse-and-test.yaml`](https://github.com/DEFRA/epr-webapps-code-deploy-templates/blob/6ff126def5c23ed6f5ba73e668c304ca9eeb4548/templates/analyse-and-test.yaml#L8-L10) but can't be used by the service builds as it's [not exposed in `epr-build-pipeline.yaml` parameters](https://github.com/DEFRA/epr-webapps-code-deploy-templates/blob/6ff126def5c23ed6f5ba73e668c304ca9eeb4548/epr-build-pipeline.yaml#L1) so can't be used and so has been replaced by `testPattern`.

The previous attempt was to widen the default pattern to `*tests*` but it resulted in existing integration tests being run in the wrong context. It was reverted in f1f95947bba670e486e82c911710e6e78c81f7b5

Tested this patch in regulator service:
- [without extra param](https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build/results?buildId=1189776&view=logs&j=060534fd-7d4a-559c-10d1-0a64d793202d&t=18a20004-01e4-56c5-ce9f-98195308e5ff&l=135) (i.e. doesn't break existing pipelines)
- [without extra param and runs additional integration tests](https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build/results?buildId=1189778&view=logs&j=060534fd-7d4a-559c-10d1-0a64d793202d&t=18a20004-01e4-56c5-ce9f-98195308e5ff&l=285)

https://eaflood.atlassian.net/browse/AMCR-42

Supports https://github.com/DEFRA/epr-regulator-service/pull/433