### PR TITLE
Docker image tag - combine build & git into same tag

### DIFF
--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -66,11 +66,8 @@ steps:
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-latest
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-latest
 
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
 
         elif [[ $(branchName) == releases* ]]
           then
@@ -78,18 +75,12 @@ steps:
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)
 
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
 
         else
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
-
-            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
-            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
+            docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
+            docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)
         fi
 
   - bash: |
@@ -101,15 +92,12 @@ steps:
         if [[ $(branchName) == 'main' ]]
           then
             echo -e "\033[0;32m $(branchName)-latest"
-            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
-            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
+            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)"
         elif [[ $(branchName) == releases* ]]
           then
             echo -e "\033[0;32m $(branchName)"
-            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
-            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
+            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)"
         else
-            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
-            echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
+            echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)-$(Build.SourceVersion)"
         fi
     displayName: "NAME OF THE IMAGE"


### PR DESCRIPTION
Having previously added a second tag for the git sha and run like that for a while it's become clear that having to choose which one to deploy isn't great either way, either you lose the build info or the git info, both of which are useful for tracing backwards and being certain about exactly what is deployed.

By putting both in the same tag name as `branch-buildid-gitsha` we get everything together and eliminate the decision of which to deploy.