### PR TITLE
SUB-219 - Added variable group for reading secrets for integration tests

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -28,6 +28,8 @@ parameters:
     type: string
     default: SonarQube
 
+variables:
+  - group: integration-test-secrets
 
 steps:
   - task: SonarQubePrepare@6
@@ -93,6 +95,8 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: 'Run Integration Tests'
     condition: eq(${{parameters.runIntegrationTests}}, true)
+    env:
+      CosmosAccountKey: $(CosmosAccountKey)
     inputs:
       command: test
       ${{ if eq(parameters.testFolder, '') }}:


### PR DESCRIPTION
Variable group integration-test-secrets added to test pipeline template.
Currently only CosmosAccountKey is required and mapped as an env var in the integration tests task