### PR TITLE
MO-130: Do not push an image if it's dependabot as we don't need to and it may error because the branch name is too long

### DIFF
--- a/templates/docker.yaml
+++ b/templates/docker.yaml
@@ -84,6 +84,10 @@ steps:
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.SourceVersion)
 
+        elif [[ $(branchName) == dependabot* ]]
+          then
+            echo -e "\033[0;32m Dependabot - not pushing"
+
         else
             docker tag ${{parameters.imageName}}:$(Build.BuildNumber) ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
             docker push ${{parameters.azureContainerRegistryName}}.azurecr.io/${{parameters.repositoryName}}:$(branchName)-$(Build.BuildNumber)
@@ -108,6 +112,9 @@ steps:
             echo -e "\033[0;32m $(branchName)"
             echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
             echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"
+        elif [[ $(branchName) == dependabot* ]]
+          then
+            echo -e "\033[0;32m none"
         else
             echo -e "\033[0;32m $(branchName)-$(Build.BuildNumber)"
             echo -e "\033[0;32m $(branchName)-$(Build.SourceVersion)"


### PR DESCRIPTION
Now some services have dependabot configured, depending on how it's configured it may result in a long branch name, which will be translated into a long tag name when pushing the image to the registry in Azure.

The tag limit is 128 characters.

We don't need dependabot sourced images in the registry so this PR skips the push if the branch name starts with dependabot.