### PR TITLE
SUB-238: code coverage

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -75,7 +75,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testPattern}}
-      arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover'
+      arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./unit-tests-coverage/coverage.opencover.xml'
       publishTestResults: true
 
   - task: CmdLine@2
@@ -101,7 +101,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj
-      arguments: '--configuration $(buildConfiguration) --filter "Category=IntegrationTest"'
+      arguments: '--configuration $(buildConfiguration) --filter "Category=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
 
   - task: CmdLine@2
     displayName: 'Stop Docker Compose'


### PR DESCRIPTION
Currently, integration tests are ignored when code coverage is calculated. This PR is to remedy this

* Specify different coverlet output locations for each test run, to allow contributions from both unit _and_ integration tests.

see test build
https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build/results?buildId=1280540&view=logs&j=060534fd-7d4a-559c-10d1-0a64d793202d

