### PR TITLE
SUB-229, DD. Integration tests categorisation

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -101,7 +101,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj
-      arguments: '--configuration $(buildConfiguration) --filter "Category=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
+      arguments: '--configuration $(buildConfiguration) --filter "Category=IntegrationTest|TestCategory=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
 
   - task: CmdLine@2
     displayName: 'Stop Docker Compose'


### PR DESCRIPTION
Allow integration tests to be filtered by `TestCategory` as well as `Category` to cater for built-in `TestCategoryAttribute`.

See [docs](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-organizing#assembly-level-categories)

See [test build](https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build/results?buildId=1296908&view=logs&j=060534fd-7d4a-559c-10d1-0a64d793202d&t=dcadaa7b-e355-5da7-a6a1-97ed8c9e583d) for [this PR](https://github.com/DEFRA/epr-pom-api-submission-status/pull/46/changes#diff-744229a732c9d02998b686519fce36aec84f186a24d06af9b4d91e752dad62e5) 