### PR TITLE
SUB-300: Declare buildConfiguration as a template parameter.

### DIFF
--- a/epr-build-pipeline.yaml
+++ b/epr-build-pipeline.yaml
@@ -69,6 +69,9 @@ parameters:
 - name: dependencyDataStorageAccount
   type: string
   default: 'devrwdinfsa1401'
+- name: buildConfiguration
+  type: string
+  default: 'Release'
 
 resources:
   repositories:
@@ -107,6 +110,7 @@ stages:
               runIntegrationTests: ${{ parameters.runIntegrationTests }}
               runNugetTasks: ${{ parameters.runNugetTasks }}
               sonarqubeInstance: ${{ parameters.sonarqubeInstance }}
+              buildConfiguration: ${{ parameters.buildConfiguration }}
 
       - job: RunGitleaksSecretScan
         displayName: Run Gitleaks Secret Scan

--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -27,6 +27,9 @@ parameters:
   - name: sonarqubeInstance
     type: string
     default: SonarQube
+  - name: buildConfiguration
+    type: string
+    default: 'Release'
 
 
 steps:
@@ -63,6 +66,7 @@ steps:
         projects: '**/*.csproj'
       ${{else}}:
         projects: ${{ parameters.projectFolder }}/*.csproj
+      arguments: '--configuration ${{ parameters.buildConfiguration }}'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests'
@@ -75,7 +79,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testPattern}}
-      arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./unit-tests-coverage/coverage.opencover.xml'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./unit-tests-coverage/coverage.opencover.xml'
       publishTestResults: true
 
   - task: CmdLine@2
@@ -101,7 +105,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj
-      arguments: '--configuration $(buildConfiguration) --filter "Category=IntegrationTest|TestCategory=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} --filter "Category=IntegrationTest|TestCategory=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
 
   - task: CmdLine@2
     displayName: 'Stop Docker Compose'

--- a/templates/tests.yaml
+++ b/templates/tests.yaml
@@ -18,6 +18,9 @@ parameters:
   - name: testProjectFolder
     type: string
     default: ''
+  - name: buildConfiguration
+    type: string
+    default: 'Release'
 
 steps:
   - script: |
@@ -54,6 +57,7 @@ steps:
       command: build
       # projects: '**/*[Uu]nit[Tt]ests/*.csproj'
       projects: '${{parameters.solutionFolder}}/${{parameters.componentDirectory}}/${{parameters.testProjectFolder}}/${{parameters.testProjectFolder}}.csproj'
+      arguments: '--configuration ${{ parameters.buildConfiguration }}'
       publishTestResults: true
 
   - task: SonarQubeAnalyze@5
@@ -71,4 +75,4 @@ steps:
       command: test
       # projects: '**/*[Uu]nit[Tt]ests/*.csproj'
       projects: '${{parameters.solutionFolder}}/${{parameters.componentDirectory}}/${{parameters.testProjectFolder}}/${{parameters.testProjectFolder}}.csproj'
-      arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/ /p:CoverletOutputFormat=opencover'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/ /p:CoverletOutputFormat=opencover'


### PR DESCRIPTION
analyse-and-test.yaml and tests.yaml passed `--configuration $(buildConfiguration)` to `dotnet test`, but no template or consuming pipeline in this repo ever defined `buildConfiguration`. ADO leaves unresolved macros as literal text, so MSBuild received the string `$(buildConfiguration)` as the Configuration value and emitted binaries into `bin/$(buildConfiguration)/net{version}/`. On .NET 6/8 this was silently tolerated, but the .NET 10 SDK made it visible in two ways:

  * The SDK now auto-defines an uppercased preprocessor symbol from the Configuration name, so the compiler received `/define:$(BUILDCONFIGURATION)` and raised MSB3052 across every project.
  * The VSTest host URL-encodes unresolved path segments, so integration test runs targeted `bin/%24%28buildConfiguration%29/net10.0/*.dll` and failed to load assemblies.

Fixed this by declaring `buildConfiguration` as a template parameter (default `Release`) in epr-build-pipeline.yaml and threaded it through to analyse-and-test.yaml and tests.yaml. Both templates now use `${{ parameters.buildConfiguration }}` in place of `$(buildConfiguration)`.

Also added `--configuration` to the `Run Build` steps in both templates: previously build ran in Debug (the DotNetCoreCLI@2 default) while test tried to run against the parameter value, forcing an implicit rebuild and leaving Debug binaries on disk. Build and test now share one configuration.

Existing consumers are unaffected: the `Release` default matches the effective behaviour they were already getting when the placeholder resolved to nothing meaningful, and any consumer can override the parameter to select a different configuration.