### PR TITLE
SUB-300: Pass AzureBuild=true to dotnet build and test commands.

### DIFF
--- a/templates/analyse-and-test.yaml
+++ b/templates/analyse-and-test.yaml
@@ -66,7 +66,7 @@ steps:
         projects: '**/*.csproj'
       ${{else}}:
         projects: ${{ parameters.projectFolder }}/*.csproj
-      arguments: '--configuration ${{ parameters.buildConfiguration }}'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:AzureBuild=true'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests'
@@ -79,7 +79,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testPattern}}
-      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./unit-tests-coverage/coverage.opencover.xml'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:AzureBuild=true /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./unit-tests-coverage/coverage.opencover.xml'
       publishTestResults: true
 
   - task: CmdLine@2
@@ -105,7 +105,7 @@ steps:
       ${{else}}:
         projects:  |
           ${{ parameters.testFolder}}/**/*.csproj
-      arguments: '--configuration ${{ parameters.buildConfiguration }} --filter "Category=IntegrationTest|TestCategory=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:AzureBuild=true --filter "Category=IntegrationTest|TestCategory=IntegrationTest" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./integration-tests-coverage/coverage.opencover.xml'
 
   - task: CmdLine@2
     displayName: 'Stop Docker Compose'

--- a/templates/tests.yaml
+++ b/templates/tests.yaml
@@ -57,7 +57,7 @@ steps:
       command: build
       # projects: '**/*[Uu]nit[Tt]ests/*.csproj'
       projects: '${{parameters.solutionFolder}}/${{parameters.componentDirectory}}/${{parameters.testProjectFolder}}/${{parameters.testProjectFolder}}.csproj'
-      arguments: '--configuration ${{ parameters.buildConfiguration }}'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:AzureBuild=true'
       publishTestResults: true
 
   - task: SonarQubeAnalyze@5
@@ -75,4 +75,4 @@ steps:
       command: test
       # projects: '**/*[Uu]nit[Tt]ests/*.csproj'
       projects: '${{parameters.solutionFolder}}/${{parameters.componentDirectory}}/${{parameters.testProjectFolder}}/${{parameters.testProjectFolder}}.csproj'
-      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/ /p:CoverletOutputFormat=opencover'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} /p:AzureBuild=true /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/ /p:CoverletOutputFormat=opencover'


### PR DESCRIPTION
Consumer solutions (e.g. epr-backend-account-microservice) carry an EF-migration AfterBuild target in their Data project:

  <Target Name="GenerateSqlScript" AfterTargets="AfterBuild"
          Condition="$(AzureBuild) != true">
    <Exec Condition="$(Configuration) == Release"
          Command="dotnet ef migrations script ..." />
  </Target>

Their Directory.Build.props defaults AzureBuild to true so the target is normally skipped, but nothing in this repo was setting the property explicitly. After SUB-300 made these templates run in Release configuration, the inner Exec condition became satisfied and any consumer whose props file was absent, overridden, or not imported would run `dotnet ef migrations script` inside the CI build — a step that belongs to docker-sql-migration-script.yaml, not to analyse-and-test / tests.

Passing the flag on the MSBuild command line pins the value at the highest-precedence source, so the migration target is reliably skipped regardless of what the consumer's props files do. Pipelines that need the SQL script continue to generate it via docker-sql-migration-script.yaml.